### PR TITLE
Extract localize function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.2.0
+- Expose `localize` function
+
 ## 1.1.5
 - Fix typo in README
 - Set MIT as license in package.json

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ import { localize } from 'pseudo-localization';
 import localize from 'pseudo-localization/localize';
 
 console.log(localize('hello')); // --> ħḗḗŀŀǿǿ
-console.log(localize('hello', { strategy: 'bidi' })); // --> ɥǝʅʅo‬
+console.log(localize('hello', { strategy: 'bidi' })); // --> oʅʅǝɥ
 ```
 
 ## Strategies

--- a/README.md
+++ b/README.md
@@ -68,6 +68,18 @@ class Page extends React.Component {
 }
 ```
 
+You can also call the underlying `localize` function to pseudo-localize any string.
+
+
+```js
+import { localize } from 'pseudo-localization';
+// OR
+import localize from 'pseudo-localization/localize';
+
+console.log(localize('hello')); // --> ħḗḗŀŀǿǿ
+console.log(localize('hello', { strategy: 'bidi' })); // --> ɥǝʅʅo‬
+```
+
 ## Strategies
 `pseudo-localization` supports two strategies:
 

--- a/index.js
+++ b/index.js
@@ -1,121 +1,6 @@
+const psuedoLocalizeString = require('./localize');
+
 const pseudoLocalization = (() => {
-  const ACCENTED_MAP = {
-    a: "ȧ",
-    A: "Ȧ",
-    b: "ƀ",
-    B: "Ɓ",
-    c: "ƈ",
-    C: "Ƈ",
-    d: "ḓ",
-    D: "Ḓ",
-    e: "ḗ",
-    E: "Ḗ",
-    f: "ƒ",
-    F: "Ƒ",
-    g: "ɠ",
-    G: "Ɠ",
-    h: "ħ",
-    H: "Ħ",
-    i: "ī",
-    I: "Ī",
-    j: "ĵ",
-    J: "Ĵ",
-    k: "ķ",
-    K: "Ķ",
-    l: "ŀ",
-    L: "Ŀ",
-    m: "ḿ",
-    M: "Ḿ",
-    n: "ƞ",
-    N: "Ƞ",
-    o: "ǿ",
-    O: "Ǿ",
-    p: "ƥ",
-    P: "Ƥ",
-    q: "ɋ",
-    Q: "Ɋ",
-    r: "ř",
-    R: "Ř",
-    s: "ş",
-    S: "Ş",
-    t: "ŧ",
-    T: "Ŧ",
-    v: "ṽ",
-    V: "Ṽ",
-    u: "ŭ",
-    U: "Ŭ",
-    w: "ẇ",
-    W: "Ẇ",
-    x: "ẋ",
-    X: "Ẋ",
-    y: "ẏ",
-    Y: "Ẏ",
-    z: "ẑ",
-    Z: "Ẑ"
-  };
-
-  const BIDI_MAP = {
-    a: "ɐ",
-    A: "∀",
-    b: "q",
-    B: "Ԑ",
-    c: "ɔ",
-    C: "Ↄ",
-    d: "p",
-    D: "ᗡ",
-    e: "ǝ",
-    E: "Ǝ",
-    f: "ɟ",
-    F: "Ⅎ",
-    g: "ƃ",
-    G: "⅁",
-    h: "ɥ",
-    H: "H",
-    i: "ı",
-    I: "I",
-    j: "ɾ",
-    J: "ſ",
-    k: "ʞ",
-    K: "Ӽ",
-    l: "ʅ",
-    L: "⅂",
-    m: "ɯ",
-    M: "W",
-    n: "u",
-    N: "N",
-    o: "o",
-    O: "O",
-    p: "d",
-    P: "Ԁ",
-    q: "b",
-    Q: "Ò",
-    r: "ɹ",
-    R: "ᴚ",
-    s: "s",
-    S: "S",
-    t: "ʇ",
-    T: "⊥",
-    u: "n",
-    U: "∩",
-    v: "ʌ",
-    V: "Ʌ",
-    w: "ʍ",
-    W: "M",
-    x: "x",
-    X: "X",
-    y: "ʎ",
-    Y: "⅄",
-    z: "z",
-    Z: "Z"
-  };
-
-  let opts = {
-    prefix: "",
-    postfix: "",
-    map: ACCENTED_MAP,
-    elongate: true
-  };
-
   const textNodesUnder = element => {
     const walker = document.createTreeWalker(
       element,
@@ -133,35 +18,10 @@ const pseudoLocalization = (() => {
     return textNodes;
   };
 
-  const psuedoLocalizeString = string => {
-    let pseudoLocalizedText = "";
-    for (let character of string) {
-      if (opts.map[character]) {
-        const cl = character.toLowerCase();
-        // duplicate "a", "e", "o" and "u" to emulate ~30% longer text
-        if (
-          opts.elongate &&
-          (cl === "a" || cl === "e" || cl === "o" || cl === "u")
-        ) {
-          pseudoLocalizedText += opts.map[character] + opts.map[character];
-        } else pseudoLocalizedText += opts.map[character];
-      } else pseudoLocalizedText += character;
-    }
-
-    // If this string is from the DOM, it should already contain the pre- and postfix.
-    if (
-      pseudoLocalizedText.startsWith(opts.prefix) &&
-      pseudoLocalizedText.endsWith(opts.postfix)
-    ) {
-      return pseudoLocalizedText;
-    }
-    return opts.prefix + pseudoLocalizedText + opts.postfix;
-  };
-
-  const pseudoLocalize = element => {
+  const pseudoLocalize = (element, options) => {
     const textNodesUnderElement = textNodesUnder(element);
     for (let textNode of textNodesUnderElement) {
-      textNode.nodeValue = psuedoLocalizeString(textNode.nodeValue);
+      textNode.nodeValue = psuedoLocalizeString(textNode.nodeValue, options);
     }
   };
 
@@ -197,17 +57,8 @@ const pseudoLocalization = (() => {
     subtree: true
   };
 
-  const start = (options = { strategy: "accented" }) => {
-    if (options.strategy === "bidi") {
-      // Surround words with Unicode formatting marks forcing
-      // the RTL directionality of characters.
-      opts.prefix = "\u202e";
-      opts.postfix = "\u202c";
-      opts.map = BIDI_MAP;
-      opts.elongate = false;
-    }
-
-    pseudoLocalize(document.body);
+  const start = (options) => {
+    pseudoLocalize(document.body, options);
     observer.observe(document.body, observerConfig);
   };
 
@@ -217,7 +68,8 @@ const pseudoLocalization = (() => {
 
   return {
     start,
-    stop
+    stop,
+    localize: psuedoLocalizeString,
   };
 })();
 

--- a/localize.js
+++ b/localize.js
@@ -1,0 +1,155 @@
+const ACCENTED_MAP = {
+  a: "ȧ",
+  A: "Ȧ",
+  b: "ƀ",
+  B: "Ɓ",
+  c: "ƈ",
+  C: "Ƈ",
+  d: "ḓ",
+  D: "Ḓ",
+  e: "ḗ",
+  E: "Ḗ",
+  f: "ƒ",
+  F: "Ƒ",
+  g: "ɠ",
+  G: "Ɠ",
+  h: "ħ",
+  H: "Ħ",
+  i: "ī",
+  I: "Ī",
+  j: "ĵ",
+  J: "Ĵ",
+  k: "ķ",
+  K: "Ķ",
+  l: "ŀ",
+  L: "Ŀ",
+  m: "ḿ",
+  M: "Ḿ",
+  n: "ƞ",
+  N: "Ƞ",
+  o: "ǿ",
+  O: "Ǿ",
+  p: "ƥ",
+  P: "Ƥ",
+  q: "ɋ",
+  Q: "Ɋ",
+  r: "ř",
+  R: "Ř",
+  s: "ş",
+  S: "Ş",
+  t: "ŧ",
+  T: "Ŧ",
+  v: "ṽ",
+  V: "Ṽ",
+  u: "ŭ",
+  U: "Ŭ",
+  w: "ẇ",
+  W: "Ẇ",
+  x: "ẋ",
+  X: "Ẋ",
+  y: "ẏ",
+  Y: "Ẏ",
+  z: "ẑ",
+  Z: "Ẑ"
+};
+
+const BIDI_MAP = {
+  a: "ɐ",
+  A: "∀",
+  b: "q",
+  B: "Ԑ",
+  c: "ɔ",
+  C: "Ↄ",
+  d: "p",
+  D: "ᗡ",
+  e: "ǝ",
+  E: "Ǝ",
+  f: "ɟ",
+  F: "Ⅎ",
+  g: "ƃ",
+  G: "⅁",
+  h: "ɥ",
+  H: "H",
+  i: "ı",
+  I: "I",
+  j: "ɾ",
+  J: "ſ",
+  k: "ʞ",
+  K: "Ӽ",
+  l: "ʅ",
+  L: "⅂",
+  m: "ɯ",
+  M: "W",
+  n: "u",
+  N: "N",
+  o: "o",
+  O: "O",
+  p: "d",
+  P: "Ԁ",
+  q: "b",
+  Q: "Ò",
+  r: "ɹ",
+  R: "ᴚ",
+  s: "s",
+  S: "S",
+  t: "ʇ",
+  T: "⊥",
+  u: "n",
+  U: "∩",
+  v: "ʌ",
+  V: "Ʌ",
+  w: "ʍ",
+  W: "M",
+  x: "x",
+  X: "X",
+  y: "ʎ",
+  Y: "⅄",
+  z: "z",
+  Z: "Z"
+};
+
+const strategies = {
+  accented: {
+    prefix: "",
+    postfix: "",
+    map: ACCENTED_MAP,
+    elongate: true
+  },
+  bidi: {
+    // Surround words with Unicode formatting marks forcing
+    // the RTL directionality of characters.
+    prefix: "\u202e",
+    postfix: "\u202c",
+    map: BIDI_MAP,
+    elongate: false
+  }
+};
+
+const psuedoLocalizeString = (string, options = { strategy: "accented" }) => {
+  let opts = strategies[options.strategy];
+
+  let pseudoLocalizedText = "";
+  for (let character of string) {
+    if (opts.map[character]) {
+      const cl = character.toLowerCase();
+      // duplicate "a", "e", "o" and "u" to emulate ~30% longer text
+      if (
+        opts.elongate &&
+        (cl === "a" || cl === "e" || cl === "o" || cl === "u")
+      ) {
+        pseudoLocalizedText += opts.map[character] + opts.map[character];
+      } else pseudoLocalizedText += opts.map[character];
+    } else pseudoLocalizedText += character;
+  }
+
+  // If this string is from the DOM, it should already contain the pre- and postfix.
+  if (
+    pseudoLocalizedText.startsWith(opts.prefix) &&
+    pseudoLocalizedText.endsWith(opts.postfix)
+  ) {
+    return pseudoLocalizedText;
+  }
+  return opts.prefix + pseudoLocalizedText + opts.postfix;
+};
+
+module.exports = psuedoLocalizeString;


### PR DESCRIPTION
I split it into two files so the `localize` function will be loadable in Node.js environments which don't have `MutationObserver`.

```js
import { localize } from 'pseudo-localization';
// OR
import localize from 'pseudo-localization/localize';

console.log(localize('hello')); // --> ħḗḗŀŀǿǿ
console.log(localize('hello', { strategy: 'bidi' })); // --> ɥǝʅʅo‬
```

I noticed there's a copy of the script in the `hamlet.html` file, I didn't update that. I could change it to pull from [`unpkg`](https://unpkg.com/pseudo-localization) and set up a Rollup UMD bundle if you'd like?

Closes #3 