### PR TITLE
3.0.0 Add TS definitions and remove default export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,39 +1,68 @@
+#3.0.0
+
+- Add Typescript definitions
+- Remove default export usage.
+  - **BREAKING** `import` usage will have to change from
+    ```js
+    import pseudoLocalization from 'pseudo-localization';
+    ```
+    to
+    ```js
+    import * as pseudoLocalization from 'pseudo-localization';
+    ```
+  - **BREAKING** `require` usage will have to change from
+    ```js
+    const pseudoLocalization = require('pseudo-localization').default;
+    ```
+    to
+    ```js
+    const pseudoLocalization = require('pseudo-localization');
+    ```
+
 ##2.0.2
+
 - Fix a bug where blacklisted nodes would get pseudo-localized when mutated in the DOM
 
 ##2.0.1
+
 - Mention in package.json description that `pseudo-localization` works with nodejs.
 
 ##2.0.0
+
 - Safeguard childlist mutations and empty strings https://github.com/tryggvigy/pseudo-localization/pull/12
   - Fixes https://github.com/tryggvigy/pseudo-localization/issues/6 and https://github.com/tryggvigy/pseudo-localization/issues/11
 - Fix a bug where DOM mutation localizations did not respect the strategy specified https://github.com/tryggvigy/pseudo-localization/pull/16
 - Refactor internals to use import/export ES modules https://github.com/tryggvigy/pseudo-localization/pull/16
   - **BREAKING** `require` usage will have to change from
-     ```js
-        const pseudoLocalization = require('pseudo-localization');
-     ```
-     to
     ```js
-      const pseudoLocalization = require('pseudo-localization').default;
+    const pseudoLocalization = require('pseudo-localization');
+    ```
+    to
+    ```js
+    const pseudoLocalization = require('pseudo-localization').default;
     ```
 - Transform to "not dead" browsers through babel https://github.com/tryggvigy/pseudo-localization/pull/16
   - Fixes https://github.com/tryggvigy/pseudo-localization/issues/8
 
 ##1.3.0
+
 - Allow blacklisting nodes ([#9](https://github.com/tryggvigy/pseudo-localization/pull/9))
 
 ## 1.2.0
+
 - Expose `localize` function
 
 ## 1.1.5
+
 - Fix typo in README
 - Set MIT as license in package.json
 
 ## 1.1.4
+
 - Update explanatory picture in README.md
 
 ## 1.1.3
+
 - Add support for bidirectional text
   - `pseudoLocalization.start({ strategy: 'bidi' });`
 - Changed several things to improve legibility

--- a/README.md
+++ b/README.md
@@ -32,9 +32,9 @@ Copy paste the files in [`src`](https://github.com/tryggvigy/pseudo-localization
 `pseudo-localization` can be used like so:
 
 ```js
-import pseudoLocalization from 'pseudo-localization';
+import * as pseudoLocalization from 'pseudo-localization';
 // Or using CommonJS
-// const pseudoLocalization = require('pseudo-localization').default;
+// const pseudoLocalization = require('pseudo-localization');
 
 pseudoLocalization.start();
 
@@ -47,14 +47,14 @@ component lifecycles. In React for example:
 
 ```js
 import React from 'react';
-import pseudoLocalization from 'pseudo-localization';
+import { start, stop } from 'pseudo-localization';
 
 class PseudoLocalization extends React.Component {
   componentDidMount() {
-    pseudoLocalization.start();
+    start();
   }
   componentWillUnmount() {
-    pseudoLocalization.stop();
+    stop();
   }
 }
 
@@ -108,7 +108,7 @@ Any strings that do not pass through the translation function will now stand out
 
 ### accented - Ȧȧƈƈḗḗƞŧḗḗḓ Ḗḗƞɠŀīīşħ
 
-Usage: `pseudoLocalization.start({ strategy: 'accented' });` or simply `pseudoLocalization.start();`.
+Usage: `start({ strategy: 'accented' });` or simply `start();`.
 
 In Accented English all Latin letters are replaced by accented
 Unicode counterparts which don't impair the readability of the content.
@@ -122,7 +122,7 @@ experience of international users.
 
 ### bidi - ɥsıʅƃuƎ ıpıԐ
 
-Usage: `pseudoLocalization.start({ strategy: 'bidi' });`.
+Usage: `start({ strategy: 'bidi' });`.
 
 Bidi English is a fake [RTL](https://developer.mozilla.org/en-US/docs/Glossary/rtl) locale.  All words are surrounded by
 Unicode formatting marks forcing the RTL directionality of characters.
@@ -143,11 +143,11 @@ In addition, the pseudo-localization process may uncover places where an element
 
 ## Docs
 `pseudo-localization` exports three functions.
-- `pseudoLocalization.start(options)`
-- `pseudoLocalization.stop()`
-- `pseudoLocalization.localize(string, options)`
+- `start(options)`
+- `stop()`
+- `localize(string, options)`
 
-### `pseudoLocalization.start(options)`
+### `start(options)`
 Pseudo localizes the page and watched the DOM for additions/updates to continuously pseudo localize new content.
 
 Accepts an `options` object as an argument. Here are the keys in the `options` object.
@@ -158,12 +158,12 @@ The pseudo localization strategy to use when transforming strings. Accepted valu
 #### `blacklistedNodeNames` - default (`['STYLE']`)
 An array of [Node.nodeName](https://developer.mozilla.org/en-US/docs/Web/API/Node/nodeName) strings that will be ignored when localizing. This is useful for skipping `<style>`, `<text>` svg nodes or other nodes that potentially doesn't make sense to apply pseudo localization to. `<style>` is skipped by default when `blacklistedNodeNames` is not provided.
 
-### `pseudoLocalization.stop()`
+### `stop()`
 Stops watching the DOM for additions/updates to continuously pseudo localize new content.
 
-### `pseudoLocalization.localize(string, options)`
+### `localize(string, options)`
 Accepts a string to apply pseudo localization to. Returns the pseudo localized version on the string.
-This function is used by `pseudoLocalization.start` internally.
+This function is used by the `start` function internally.
 
 Accepts an `options` object as an argument. Here are the keys in the `options` object.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2021,8 +2021,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2043,14 +2042,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2065,20 +2062,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2195,8 +2189,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2208,7 +2201,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2223,7 +2215,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2231,14 +2222,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -2257,7 +2246,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2338,8 +2326,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2351,7 +2338,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2437,8 +2423,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2474,7 +2459,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2494,7 +2478,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2538,14 +2521,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -2923,8 +2904,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "is-fullwidth-code-point": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pseudo-localization",
-  "version": "2.0.2",
+  "version": "3.0.0",
   "description": "Dynamic pseudo-localization in the browser and nodejs",
   "main": "lib/index.js",
   "files": [

--- a/pseudo-localization.d.ts
+++ b/pseudo-localization.d.ts
@@ -1,0 +1,20 @@
+// Type definitions for pseudo-localization
+// Project: pseudo-localization
+// Definitions by: Tryggvi Gylfason https://github.com/tryggvigy
+
+type Options = { strategy?: 'accented' | 'bidi' };
+type BrowserOptions = Options & { blacklistedNodeNames?: Array<string> };
+
+namespace pseudoLocalization {
+  export function start(options?: BrowserOptions): void;
+  export function stop(): void;
+  export function localize(str: string, options?: Options): void;
+}
+
+declare module 'pseudo-localization' {
+  // allow for require syntax
+  exports = pseudoLocalization
+  export function start(options?: BrowserOptions): void;
+  export function stop(): void;
+  export function localize(str: string, options?: Options): void;
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,112 +1,102 @@
-import pseudoLocalizeString from './localize.js';
+import { pseudoLocalizeString } from './pseudoLocalizeString.js';
+
+const opts = {
+  blacklistedNodeNames: ['STYLE'],
+};
+
+// Observer for dom updates. Initialization is defered to make parts
+// of the API safe to use in non-browser environments like nodejs
+let observer = null;
+const observerConfig = {
+  characterData: true,
+  childList: true,
+  subtree: true,
+};
+
+const textNodesUnder = element => {
+  const walker = document.createTreeWalker(
+    element,
+    NodeFilter.SHOW_TEXT,
+    node => {
+      const isAllWhitespace = !/[^\s]/.test(node.nodeValue);
+      if (isAllWhitespace) return NodeFilter.FILTER_REJECT;
+
+      const isBlacklistedNode = opts.blacklistedNodeNames.includes(
+        node.parentElement.nodeName
+      );
+      if (isBlacklistedNode) return NodeFilter.FILTER_REJECT;
+
+      return NodeFilter.FILTER_ACCEPT;
+    }
+  );
+
+  let currNode;
+  const textNodes = [];
+  while ((currNode = walker.nextNode())) textNodes.push(currNode);
+  return textNodes;
+};
+
+const isNonEmptyString = str => str && typeof str === 'string';
+
+const pseudoLocalize = element => {
+  const textNodesUnderElement = textNodesUnder(element);
+  for (let textNode of textNodesUnderElement) {
+    const nodeValue = textNode.nodeValue;
+    if (isNonEmptyString(nodeValue)) {
+      textNode.nodeValue = pseudoLocalizeString(nodeValue, opts);
+    }
+  }
+};
+
+const domMutationCallback = mutationsList => {
+  for (let mutation of mutationsList) {
+    if (mutation.type === 'childList' && mutation.addedNodes.length > 0) {
+      // Turn the observer off while performing dom manipulation to prevent
+      // infinite dom mutation callback loops
+      observer.disconnect();
+      // For every node added, recurse down it's subtree and convert
+      // all children as well
+      mutation.addedNodes.forEach(pseudoLocalize);
+      observer.observe(document.body, observerConfig);
+    } else if (mutation.type === 'characterData') {
+      const nodeValue = mutation.target.nodeValue;
+      const isBlacklistedNode = opts.blacklistedNodeNames.includes(
+        mutation.target.parentElement.nodeName
+      );
+      if (isNonEmptyString(nodeValue) && !isBlacklistedNode) {
+        // Turn the observer off while performing dom manipulation to prevent
+        // infinite dom mutation callback loops
+        observer.disconnect();
+        // The target will always be a text node so it can be converted
+        // directly
+        mutation.target.nodeValue = pseudoLocalizeString(nodeValue, opts);
+        observer.observe(document.body, observerConfig);
+      }
+    }
+  }
+};
+
+export const start = ({
+  strategy = 'accented',
+  blacklistedNodeNames = opts.blacklistedNodeNames,
+} = {}) => {
+  opts.blacklistedNodeNames = blacklistedNodeNames;
+  opts.strategy = strategy;
+  // Pseudo localize the DOM
+  pseudoLocalize(document.body);
+  // Start observing the DOM for changes and run
+  // pseudo localization on any added text nodes
+  observer = new MutationObserver(domMutationCallback);
+  observer.observe(document.body, observerConfig);
+};
+
+export const stop = () => {
+  observer && observer.disconnect();
+};
 
 /**
  * export the underlying pseudo localization function so this import style
  *  import { localize } from 'pseudo-localization';
  * can be used.
  */
-export { default as localize } from './localize.js';
-
-const pseudoLocalization = (() => {
-  const opts = {
-    blacklistedNodeNames: ['STYLE'],
-  };
-
-  // Observer for dom updates. Initialization is defered to make parts
-  // of the API safe to use in non-browser environments like nodejs
-  let observer = null;
-  const observerConfig = {
-    characterData: true,
-    childList: true,
-    subtree: true,
-  };
-
-  const textNodesUnder = element => {
-    const walker = document.createTreeWalker(
-      element,
-      NodeFilter.SHOW_TEXT,
-      node => {
-        const isAllWhitespace = !/[^\s]/.test(node.nodeValue);
-        if (isAllWhitespace) return NodeFilter.FILTER_REJECT;
-
-        const isBlacklistedNode = opts.blacklistedNodeNames.includes(
-          node.parentElement.nodeName
-        );
-        if (isBlacklistedNode) return NodeFilter.FILTER_REJECT;
-
-        return NodeFilter.FILTER_ACCEPT;
-      }
-    );
-
-    let currNode;
-    const textNodes = [];
-    while ((currNode = walker.nextNode())) textNodes.push(currNode);
-    return textNodes;
-  };
-
-  const isNonEmptyString = str => str && typeof str === 'string';
-
-  const pseudoLocalize = element => {
-    const textNodesUnderElement = textNodesUnder(element);
-    for (let textNode of textNodesUnderElement) {
-      const nodeValue = textNode.nodeValue;
-      if (isNonEmptyString(nodeValue)) {
-        textNode.nodeValue = pseudoLocalizeString(nodeValue, opts);
-      }
-    }
-  };
-
-  const domMutationCallback = mutationsList => {
-    for (let mutation of mutationsList) {
-      if (mutation.type === 'childList' && mutation.addedNodes.length > 0) {
-        // Turn the observer off while performing dom manipulation to prevent
-        // infinite dom mutation callback loops
-        observer.disconnect();
-        // For every node added, recurse down it's subtree and convert
-        // all children as well
-        mutation.addedNodes.forEach(pseudoLocalize);
-        observer.observe(document.body, observerConfig);
-      } else if (mutation.type === 'characterData') {
-        const nodeValue = mutation.target.nodeValue;
-        const isBlacklistedNode = opts.blacklistedNodeNames.includes(
-          mutation.target.parentElement.nodeName
-        );
-        if (isNonEmptyString(nodeValue) && !isBlacklistedNode) {
-          // Turn the observer off while performing dom manipulation to prevent
-          // infinite dom mutation callback loops
-          observer.disconnect();
-          // The target will always be a text node so it can be converted
-          // directly
-          mutation.target.nodeValue = pseudoLocalizeString(nodeValue, opts);
-          observer.observe(document.body, observerConfig);
-        }
-      }
-    }
-  };
-
-  const start = ({
-    strategy = 'accented',
-    blacklistedNodeNames = opts.blacklistedNodeNames,
-  } = {}) => {
-    opts.blacklistedNodeNames = blacklistedNodeNames;
-    opts.strategy = strategy;
-    // Pseudo localize the DOM
-    pseudoLocalize(document.body);
-    // Start observing the DOM for changes and run
-    // pseudo localization on any added text nodes
-    observer = new MutationObserver(domMutationCallback);
-    observer.observe(document.body, observerConfig);
-  };
-
-  const stop = () => {
-    observer && observer.disconnect();
-  };
-
-  return {
-    start,
-    stop,
-    localize: pseudoLocalizeString,
-  };
-})();
-
-export default pseudoLocalization;
+export { pseudoLocalizeString as localize } from './pseudoLocalizeString.js';

--- a/src/pseudoLocalizeString.js
+++ b/src/pseudoLocalizeString.js
@@ -1,0 +1,156 @@
+const ACCENTED_MAP = {
+  a: 'ȧ',
+  A: 'Ȧ',
+  b: 'ƀ',
+  B: 'Ɓ',
+  c: 'ƈ',
+  C: 'Ƈ',
+  d: 'ḓ',
+  D: 'Ḓ',
+  e: 'ḗ',
+  E: 'Ḗ',
+  f: 'ƒ',
+  F: 'Ƒ',
+  g: 'ɠ',
+  G: 'Ɠ',
+  h: 'ħ',
+  H: 'Ħ',
+  i: 'ī',
+  I: 'Ī',
+  j: 'ĵ',
+  J: 'Ĵ',
+  k: 'ķ',
+  K: 'Ķ',
+  l: 'ŀ',
+  L: 'Ŀ',
+  m: 'ḿ',
+  M: 'Ḿ',
+  n: 'ƞ',
+  N: 'Ƞ',
+  o: 'ǿ',
+  O: 'Ǿ',
+  p: 'ƥ',
+  P: 'Ƥ',
+  q: 'ɋ',
+  Q: 'Ɋ',
+  r: 'ř',
+  R: 'Ř',
+  s: 'ş',
+  S: 'Ş',
+  t: 'ŧ',
+  T: 'Ŧ',
+  v: 'ṽ',
+  V: 'Ṽ',
+  u: 'ŭ',
+  U: 'Ŭ',
+  w: 'ẇ',
+  W: 'Ẇ',
+  x: 'ẋ',
+  X: 'Ẋ',
+  y: 'ẏ',
+  Y: 'Ẏ',
+  z: 'ẑ',
+  Z: 'Ẑ',
+};
+
+const BIDI_MAP = {
+  a: 'ɐ',
+  A: '∀',
+  b: 'q',
+  B: 'Ԑ',
+  c: 'ɔ',
+  C: 'Ↄ',
+  d: 'p',
+  D: 'ᗡ',
+  e: 'ǝ',
+  E: 'Ǝ',
+  f: 'ɟ',
+  F: 'Ⅎ',
+  g: 'ƃ',
+  G: '⅁',
+  h: 'ɥ',
+  H: 'H',
+  i: 'ı',
+  I: 'I',
+  j: 'ɾ',
+  J: 'ſ',
+  k: 'ʞ',
+  K: 'Ӽ',
+  l: 'ʅ',
+  L: '⅂',
+  m: 'ɯ',
+  M: 'W',
+  n: 'u',
+  N: 'N',
+  o: 'o',
+  O: 'O',
+  p: 'd',
+  P: 'Ԁ',
+  q: 'b',
+  Q: 'Ò',
+  r: 'ɹ',
+  R: 'ᴚ',
+  s: 's',
+  S: 'S',
+  t: 'ʇ',
+  T: '⊥',
+  u: 'n',
+  U: '∩',
+  v: 'ʌ',
+  V: 'Ʌ',
+  w: 'ʍ',
+  W: 'M',
+  x: 'x',
+  X: 'X',
+  y: 'ʎ',
+  Y: '⅄',
+  z: 'z',
+  Z: 'Z',
+};
+
+const strategies = {
+  accented: {
+    prefix: '',
+    postfix: '',
+    map: ACCENTED_MAP,
+    elongate: true,
+  },
+  bidi: {
+    // Surround words with Unicode formatting marks forcing
+    // right-to-left directionality of characters
+    prefix: '\u202e',
+    postfix: '\u202c',
+    map: BIDI_MAP,
+    elongate: false,
+  },
+};
+
+export const pseudoLocalizeString = (
+  string,
+  { strategy = 'accented' } = {}
+) => {
+  let opts = strategies[strategy];
+
+  let pseudoLocalizedText = '';
+  for (let character of string) {
+    if (opts.map[character]) {
+      const cl = character.toLowerCase();
+      // duplicate "a", "e", "o" and "u" to emulate ~30% longer text
+      if (
+        opts.elongate &&
+        (cl === 'a' || cl === 'e' || cl === 'o' || cl === 'u')
+      ) {
+        pseudoLocalizedText += opts.map[character] + opts.map[character];
+      } else pseudoLocalizedText += opts.map[character];
+    } else pseudoLocalizedText += character;
+  }
+
+  // If this string is from the DOM, it should already contain the pre- and postfix
+  if (
+    pseudoLocalizedText.startsWith(opts.prefix) &&
+    pseudoLocalizedText.endsWith(opts.postfix)
+  ) {
+    return pseudoLocalizedText;
+  }
+  return opts.prefix + pseudoLocalizedText + opts.postfix;
+};

--- a/src/pseudoLocalizeString.test.js
+++ b/src/pseudoLocalizeString.test.js
@@ -1,0 +1,37 @@
+import { pseudoLocalizeString } from './pseudoLocalizeString';
+
+describe('localize', () => {
+  test('accented', () => {
+    expect(pseudoLocalizeString('abcd')).toBe('ȧȧƀƈḓ');
+    // aeou are duplicated
+    expect(pseudoLocalizeString('aeou')).toBe('ȧȧḗḗǿǿŭŭ');
+    expect(pseudoLocalizeString('foo bar')).toBe('ƒǿǿǿǿ ƀȧȧř');
+    expect(pseudoLocalizeString('CAPITAL_LETTERS')).toBe('ƇȦȦƤĪŦȦȦĿ_ĿḖḖŦŦḖḖŘŞ');
+    // Everything except ASCII alphabet is passed through
+    expect(pseudoLocalizeString('123,. n -~ðÞ')).toBe('123,. ƞ -~ðÞ');
+  });
+
+  test('bidi', () => {
+    const bidi = { strategy: 'bidi' };
+
+    /**
+     * There are invisivle unicode formatting marks
+     * surrounding each output. For example
+     *
+     * "‮ɐqɔp‬" is actually "\u202e" + "ɐqɔp" + "\u202c"
+     *
+     * The presense of the formatting marks cause most UIs
+     * (likely including your text editor) to render the
+     * string backwards, if you will, or from right-to-left.
+     */
+    expect(pseudoLocalizeString('abcd', bidi)).toBe('‮ɐqɔp‬');
+    expect(pseudoLocalizeString('aeou', bidi)).toBe('‮ɐǝon‬');
+    expect(pseudoLocalizeString('foo bar', bidi)).toBe('‮ɟoo qɐɹ‬');
+    expect(pseudoLocalizeString('CAPITAL_LETTERS', bidi)).toBe(
+      '‮Ↄ∀ԀI⊥∀⅂_⅂Ǝ⊥⊥ƎᴚS‬'
+    );
+    expect(pseudoLocalizeString('123,. n -~ðÞ', bidi)).toBe('‮123,. u -~ðÞ‬');
+    // formatting marks are not duplicated if already present
+    expect(pseudoLocalizeString('‮ɟoo‬', bidi)).toBe('‮ɟoo‬');
+  });
+});


### PR DESCRIPTION
**3.0.0**

- Add Typescript definitions
- Remove default export usage.
  - **BREAKING** `import` usage will have to change from
    ```js
    import pseudoLocalization from 'pseudo-localization';
    ```
    to
    ```js
    import * as pseudoLocalization from 'pseudo-localization';
    ```
  - **BREAKING** `require` usage will have to change from
    ```js
    const pseudoLocalization = require('pseudo-localization').default;
    ```
    to
    ```js
    const pseudoLocalization = require('pseudo-localization');
    ```
