### PR TITLE
Use TS for src, compile .d.ts files, strip types with node

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+dist

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Pseudo-localization helps detect issues such as:
 npm install pseudo-localization
 ```
 
-### Manual Installation
+### Copy The Source Code
 
 Copy the files from [`src`](https://github.com/tryggvigy/pseudo-localization/blob/master/src) and use them directly.
 
@@ -148,13 +148,7 @@ stop();
 A command-line interface (CLI) is available for quick testing and automation.
 
 ```sh
-npx pseudo-localization ./path/to/file.json
-
-# Pipe a string
-echo "hello world" | npx pseudo-localization
-
-# Direct input
-npx pseudo-localization -i "hello world"
+npx pseudo-localization "hello world"
 ```
 
 ### CLI Options
@@ -163,13 +157,11 @@ npx pseudo-localization -i "hello world"
 pseudo-localization [src] [options]
 
 Positionals:
-  src  Input file or STDIN
+  src  Input string
 
 Options:
-  -o, --output  Output file (defaults to STDOUT)
   --strategy    Localization strategy (accented or bidi)
   --help        Show help
-  --version     Show version
 ```
 
 ---

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pseudo-localization",
-  "version": "3.0.1",
+  "version": "3.0.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "pseudo-localization",
-      "version": "3.0.1",
+      "version": "3.0.4",
       "license": "MIT",
       "dependencies": {
         "yargs": "^17.7.2"
@@ -17,6 +17,7 @@
       "devDependencies": {
         "@eslint/js": "^9.17.0",
         "@types/node": "^22.10.2",
+        "@types/yargs": "^17.0.33",
         "eslint": "^9.17.0",
         "globals": "^15.13.0",
         "prettier": "^3.4.2",
@@ -294,6 +295,23 @@
       "dependencies": {
         "undici-types": "~6.20.0"
       }
+    },
+    "node_modules/@types/yargs": {
+      "version": "17.0.33",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.33.tgz",
+      "integrity": "sha512-WpxBCKWPLr4xSsHgz511rFJAM+wS28w2zEO1QDNY5zM/S8ok70NNfztH0xwhqKyaK0OHCbN98LDAZuy1ctxDkA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/yargs-parser": "*"
+      }
+    },
+    "node_modules/@types/yargs-parser": {
+      "version": "21.0.3",
+      "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.3.tgz",
+      "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.18.0",
@@ -1936,6 +1954,21 @@
       "requires": {
         "undici-types": "~6.20.0"
       }
+    },
+    "@types/yargs": {
+      "version": "17.0.33",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.33.tgz",
+      "integrity": "sha512-WpxBCKWPLr4xSsHgz511rFJAM+wS28w2zEO1QDNY5zM/S8ok70NNfztH0xwhqKyaK0OHCbN98LDAZuy1ctxDkA==",
+      "dev": true,
+      "requires": {
+        "@types/yargs-parser": "*"
+      }
+    },
+    "@types/yargs-parser": {
+      "version": "21.0.3",
+      "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.3.tgz",
+      "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
+      "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
       "version": "8.18.0",

--- a/package.json
+++ b/package.json
@@ -1,37 +1,38 @@
 {
   "name": "pseudo-localization",
-  "version": "3.0.4",
+  "version": "3.1.5",
   "description": "pseudo-localization for internationalization testing",
   "files": [
-    "bin",
-    "src/localize.mjs",
-    "src/dom.mjs"
+    "dist",
+    "src"
   ],
-  "main": "./src/localize.mjs",
   "type": "module",
+  "sideEffects": false,
   "exports": {
     ".": {
-      "import": "./src/localize.mjs"
+      "types": "./dist/localize.d.ts",
+      "import": "./dist/localize.js"
     },
     "./dom": {
-      "import": "./src/dom.mjs"
+      "types": "./dist/dom.d.ts",
+      "import": "./dist/dom.js"
     }
   },
   "bin": {
-    "pseudo-localization": "./bin/pseudo-localize.mjs"
+    "pseudo-localization": "./dist/bin/pseudo-localize.js"
   },
   "engines": {
     "node": "^23"
   },
   "scripts": {
+    "build": "tsc -p tsconfig.lib.json",
+    "check-formatting": "prettier --list-different src/**/*.ts",
+    "format": "prettier --write src/**/*.ts",
+    "lint": "eslint src/**/*.ts",
     "start": "node devserver.mjs",
-    "check-formatting": "prettier --list-different src/**/*.mjs",
-    "format": "prettier --write src/**/*.mjs",
-    "lint": "eslint src/**/*.mjs",
-    "test-js": "node ./src/localize.test.mjs",
-    "test": "npm run test-js jest && npm run check-formatting && npm run check-types && npm run lint",
-    "check-types": "tsc --noEmit",
-    "tsc": "tsc"
+    "test-js": "node --experimental-strip-types --disable-warning=ExperimentalWarning --test './src/**/*.test.ts'",
+    "test": "npm run test-js && npm run check-formatting && npm run typecheck && npm run lint",
+    "typecheck": "tsc -p tsconfig.lib.json --noEmit"
   },
   "author": "Tryggvi Gylfason (http://twitter.com/tryggvigy)",
   "keywords": [
@@ -53,6 +54,7 @@
   "devDependencies": {
     "@eslint/js": "^9.17.0",
     "@types/node": "^22.10.2",
+    "@types/yargs": "^17.0.33",
     "eslint": "^9.17.0",
     "globals": "^15.13.0",
     "prettier": "^3.4.2",

--- a/src/bin/pseudo-localize.ts
+++ b/src/bin/pseudo-localize.ts
@@ -2,7 +2,7 @@
 
 import yargs from 'yargs/yargs';
 import { hideBin } from 'yargs/helpers';
-import { pseudoLocalizeString } from '../src/localize.mjs';
+import { pseudoLocalizeString } from '../localize.ts';
 
 yargs(hideBin(process.argv))
   .usage(
@@ -13,13 +13,14 @@ yargs(hideBin(process.argv))
         .positional('string', {
           describe: 'String to pseudo-localize',
           type: 'string',
+          demandOption: true,
         })
         .option('strategy', {
           alias: 's',
           type: 'string',
           describe: 'Set the strategy for localization',
-          choices: ['accented', 'bidi'],
-          default: 'accented',
+          choices: ['accented', 'bidi'] as const,
+          default: 'accented' as const,
         });
     },
     ({ string, strategy }) => {
@@ -27,5 +28,4 @@ yargs(hideBin(process.argv))
     }
   )
   .help()
-  .version()
   .parse();

--- a/src/localize.test.ts
+++ b/src/localize.test.ts
@@ -1,6 +1,6 @@
 import test from 'node:test';
 import { strict as assert } from 'node:assert';
-import { pseudoLocalizeString as localize } from './localize.mjs';
+import { pseudoLocalizeString as localize } from './localize.ts';
 
 test('accented', () => {
   assert.equal(localize('abcd'), 'ȧȧƀƈḓ');

--- a/src/localize.ts
+++ b/src/localize.ts
@@ -35,41 +35,45 @@ const strategies = {
   },
 };
 
-/**
- * @typedef {'accented' | 'bidi'} Strategy
- */
+type Strategy = 'accented' | 'bidi';
 
-/**
- * @typedef {Object} PseudoLocalizeStringOptions
- * @property {Strategy} [strategy] The strategy to employ.
- * - `accented`: In Accented English all Latin letters are replaced by accented
- * Unicode counterparts which don't impair the readability of the content.
- * This allows developers to quickly test if any given string is being
- * correctly displayed in its 'translated' form.  Additionally, simple
- * heuristics are used to make certain words longer to better simulate the
- * experience of international users.
- * - `bidi`: Bidi English is a fake [RTL](https://developer.mozilla.org/en-US/docs/Glossary/rtl) locale.  All words are surrounded by
-Unicode formatting marks forcing the RTL directionality of characters.
-In addition, to make the reversed text easier to read, individual
-letters are flipped.
- */
+type PseudoLocalizeStringOptions = {
+  /**
+   * The strategy to employ.
+   * - `accented`:
+   *   In Accented English all Latin letters are replaced by accented
+   *   Unicode counterparts which don't impair the readability of the content.
+   *   This allows developers to quickly test if any given string is being
+   *   correctly displayed in its 'translated' form.  Additionally, simple
+   *   heuristics are used to make certain words longer to better simulate the
+   * experience of international users.
+   * - `bidi`:
+   *  Bidi English is a fake [RTL](https://developer.mozilla.org/en-US/docs/Glossary/rtl) locale.
+   *  All words are surrounded by
+   *  Unicode formatting marks forcing the RTL directionality of characters.
+   *  In addition, to make the reversed text easier to read, individual
+   *  letters are flipped.
+   */
+  strategy?: Strategy;
+};
 
 /**
  * Pseudo-localizes a string using a specified strategy.
- * @param {string} string - The string to pseudo-localize.
- * @param {PseudoLocalizeStringOptions} options - Options for pseudo-localization.
- * @returns {string} The pseudo-localized string.
+ *
+ * @example
+ * pseudoLocalizeString('orange'); // 'ǿǿřȧȧƞɠḗḗ'
+ * pseudoLocalizeString('orange', {strategy: 'bidi'}); // 'ǝƃuɐɹo'
  */
 export const pseudoLocalizeString = (
-  string,
-  { strategy = 'accented' } = {}
+  string: string,
+  { strategy = 'accented' }: PseudoLocalizeStringOptions = {}
 ) => {
-  let opts = strategies[strategy];
+  const opts = strategies[strategy];
 
   let pseudoLocalizedText = '';
-  for (let character of string) {
+  for (const character of string) {
     if (character in opts.map) {
-      const char = /** @type {keyof typeof opts.map} */ (character);
+      const char = character as keyof typeof opts.map;
       const cl = char.toLowerCase();
       // duplicate "a", "e", "o" and "u" to emulate ~30% longer text
       if (

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,20 +1,14 @@
 {
-  "include": ["src"],
   "compilerOptions": {
-    "esModuleInterop": true,
-    "skipLibCheck": true,
-    "target": "es2022",
-    "allowJs": true,
-    "checkJs": true,
-    "resolveJsonModule": true,
-    "moduleDetection": "force",
-    "isolatedModules": true,
-    "verbatimModuleSyntax": true,
     "strict": true,
-    "noUncheckedIndexedAccess": true,
-    "noImplicitOverride": true,
-    "module": "preserve",
-    "noEmit": true,
-    "lib": ["es2022", "dom", "dom.iterable"]
-  }
+
+    // node type stripping settings
+    // https://nodejs.org/api/typescript.html#type-stripping
+    "allowImportingTsExtensions": true,
+    "rewriteRelativeImportExtensions": true,
+    "verbatimModuleSyntax": true,
+    "target": "esnext",
+    "module": "NodeNext"
+  },
+  "include": ["src/**/*.ts"]
 }

--- a/tsconfig.lib.json
+++ b/tsconfig.lib.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "declaration": true,
+    "sourceMap": true
+  },
+  "exclude": ["src/**/*.test.ts"]
+}


### PR DESCRIPTION
It turned out that using JSDoc style types in the src .mjs files wasn't working well when the library is used :(  Seems like I need to generate .d.ts files anyway, so I decided to use .ts files in the src, and use the new node `--experimental-strip-types` to run the src code as JS.

Also remove outdate text in readme.